### PR TITLE
Make RulePicker collapsible

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -403,8 +403,8 @@ webview {
   font-size: 1.5em;
   color: #fff;
   position: absolute;
-  right: -1px;
-  top: 1px;
+  right: -7px;
+  top: -1px;
 }
 
 .btn-close:hover {
@@ -427,12 +427,12 @@ webview {
   cursor: pointer;
 }
 
-.rule-selector:disabled {
+.rule-header {
   border: none;
-  width: 278px;
+  width: 268px;
   overflow: hidden;
   text-overflow: ellipsis;
-  height: 29px;
+  height: 19px;
   font-size: 13.2px;
   margin: -6px 0px 5px -6px;
   color: #fff;
@@ -441,4 +441,22 @@ webview {
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
   padding: 5px;
+  line-height: 19px;
+  cursor: pointer;
+}
+
+.rule-settings {
+  max-height: 600px;
+  transition: all 0.5s linear;
+}
+.collapsed {
+  overflow: hidden;
+}
+.collapsed .rule-header {
+  margin-bottom: -1px;
+  transition: all 0.6s linear;
+}
+.collapsed .rule-settings {
+  max-height: 0px;
+  overflow-y: hidden;
 }

--- a/src/js/components/RulePicker.react.js
+++ b/src/js/components/RulePicker.react.js
@@ -11,8 +11,16 @@ const PropertyPicker = require('./PropertyPicker.react.js');
 const SelectorPicker = require('./SelectorPicker.react.js');
 const FindSelectorTypes = require('../find-selector-types.js');
 const update = require('immutability-helper');
+const classNames = require('classnames');
 
 class RulePicker extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      collapsed: false
+    };
+  }
+
   handleRuleChanged = event => {
     this.props.onRuleChanged({
       ruleKey: this.props.ruleKey,
@@ -73,6 +81,12 @@ class RulePicker extends React.Component {
     });
   };
 
+  handleToggle = event => {
+    this.setState((prevState, props) => ({
+      collapsed: ! prevState.collapsed
+    }));
+  }
+
   render() {
     const firstRuleOption = this.props.showEmptyRuleOption ? (
       <option value={null}>Select a Rule...</option>
@@ -121,21 +135,37 @@ class RulePicker extends React.Component {
       </div>
     ) : null;
 
+    const toggler = this.state.collapsed
+      ? '\u25B6'  // right triangle
+      : '\u25BC'; // down triangle
+
+    const ruleSelector = this.props.showEmptyRuleOption ? (
+      <select
+        className="rule-selector"
+        defaultValue={this.props.ruleKey}
+        onChange={this.handleRuleChanged}
+      >
+        {firstRuleOption}
+        {this.props.availableRules.map(availableRule => (
+          <option key={availableRule.index} value={availableRule.index}>
+            {availableRule.displayName}
+          </option>
+        ))}
+      </select>
+    ) : (
+      <h2 className="rule-header" onClick={this.handleToggle}>
+        {toggler} {this.props.displayName}
+      </h2>
+    );
+
+    const classes = classNames({
+      "selectors-form": true,
+      "collapsed": !! this.state.collapsed,
+    });
+
     return (
-      <form className="selectors-form">
-        <select
-          className="rule-selector"
-          defaultValue={this.props.ruleKey}
-          onChange={this.handleRuleChanged}
-          disabled={disabled}
-        >
-          {firstRuleOption}
-          {this.props.availableRules.map(availableRule => (
-            <option key={availableRule.index} value={availableRule.index}>
-              {availableRule.displayName}
-            </option>
-          ))}
-        </select>
+      <form className={classes}>
+        {ruleSelector}
         <button className="btn-close" onClick={this.handleRemove}>
           &#10006;
         </button>


### PR DESCRIPTION
This PR alters the UI to make the RulePicker collapsible.

- [x] Small UI nits (button positions, paddings etc)
- [x] Convert select box to a h2 after selecting the rule
- [x] Add toggle icons
- [x] Add CSS animations for collapsing/expanding