### PR TITLE
Disable Watchman for Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,8 @@
   ],
   "dependencies": {
     "electron-debug": "^1.4.0"
+  },
+  "jest": {
+    "watchman": false
   }
 }


### PR DESCRIPTION
Currently Jest issues a warning since watchman is missing. This disables watchman until we have decided if we wanna use it or not.