### PR TITLE
Update default exported rules test

### DIFF
--- a/src/js/components/RuleList.react.js
+++ b/src/js/components/RuleList.react.js
@@ -102,10 +102,6 @@ class RuleList extends React.Component<Props, State> {
       maxRuleKey: props.rules.length - 1,
       allAvailableRules: allAvailableRules,
     };
-
-    this.props.onRulesJSONChanged(
-      JSON.stringify(this.exportRulesJSON(this.state))
-    );
   }
 
   getRuleSettings(ruleKey: string): ?RuleSettingsType {
@@ -353,6 +349,12 @@ class RuleList extends React.Component<Props, State> {
       });
     }
   }
+
+  componentDidMount = () => {
+    this.props.onRulesJSONChanged(
+      JSON.stringify(this.exportRulesJSON(this.state))
+    );
+  };
 
   componentDidUpdate = (prevProps: Props, prevState: State) => {
     let oldJSON = JSON.stringify(this.exportRulesJSON(prevState));

--- a/src/js/components/__tests__/RuleList.react-test.js
+++ b/src/js/components/__tests__/RuleList.react-test.js
@@ -16,23 +16,34 @@ const { mount } = Enzyme;
 const React = require('react');
 const RuleList = require('../RuleList.react.js');
 
+// Rules that are always included in the exported file
+const defaultExportedRules = [
+  {
+    class: 'TextNodeRule',
+  },
+  {
+    class: 'PassThroughRule',
+    selector: '*',
+  },
+];
+
 // Initialize Enzyme adapter
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('RuleList', () => {
-  it('should export empty rules', () => {
+  it('should export only default rules', () => {
     // Set this function as the one that will be called as fs.writeFile
     fs.__setWriteFileCallback((fileName, contents, errorCallback) => {
-      // Expected exported object has no rules
+      // Expected exported object has onle the default rules
       const expectedRules = {
-        rules: [],
+        rules: [...defaultExportedRules],
       };
       expect(JSON.parse(contents)).toEqual(expectedRules);
     });
 
     // Mount the App component and trigger a click on the Export button
     // Exptected to trigger our writeFile callback
-    mount(<RuleList rules={[]} />)
+    mount(<RuleList onRulesJSONChanged={() => {}} rules={[]} />)
       .find('#export-button')
       .simulate('click');
   });


### PR DESCRIPTION
This PR fixes the unit test that was checking for empty rules.

We are currently exporting two hardcoded rules, which were breaking the existing test. I also moved the call to `onRulesJSONChanged` from the `RuleList` constructor to the `componentDidMount` lifecycle function.

## Test Plan
```
npm test
```

Verify all tests pass.