### PR TITLE
Ensure components are not highlighting elements upon app start

### DIFF
--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -126,7 +126,7 @@ class App extends React.Component<Props, State> {
             <Browser
               selector={this.state.selector}
               rulesJSON={this.state.rulesJSON}
-              findAttribute={this.state.findAttributeName !== null}
+              findAttribute={!!this.state.findAttributeName}
               findMultipleElements={this.state.findMultipleElements}
               onAttributesReceived={this.receiveAttributes}
               onCssSelectorResolved={this.handleBrowserCssSelectorResolved}
@@ -142,7 +142,7 @@ class App extends React.Component<Props, State> {
               onRulesJSONChanged={this.handleRulesJSONChanged}
               onFind={this.handleRuleListFind}
               findAttributeName={this.state.findAttributeName}
-              finding={this.state.findAttributeName !== null}
+              finding={!!this.state.findAttributeName}
             />
           </nav>
         </div>


### PR DESCRIPTION
This PR fixes a small issue where the `RuleList` and `Browser` components were initially set to highlight elements as if a search was on.

## Steps to reproduce resolved issue
- Run app.
- Delete the Paragraph rule shown by default (click on the X icon.)
- Move cursor over the `Browser` area.

## Expected result
No elements will be highlighted in the `Browser` component.

## Actual Result
Elements are highlighted in the `Browser` component, as if we had clicked to find a selector.

## Solution
The problem we have is that `undefined !== null` is equal to `true`. Replaced null check with `!!`.