### PR TITLE
Fix select value warning

### DIFF
--- a/src/js/components/PropertyPicker.react.js
+++ b/src/js/components/PropertyPicker.react.js
@@ -153,20 +153,16 @@ class PropertyPicker extends React.Component<Props> {
           <label htmlFor={this.props.name} className="sub-label">
             Attribute
           </label>
-          <select onChange={this.handleSelectedAttributeChanged}>
+          <select
+            onChange={this.handleSelectedAttributeChanged}
+            value={this.props.defaultAttribute}
+          >
             {this.props.attributes &&
               this.props.attributes.map(attribute => (
                 <option
                   value={attribute.name}
                   data-attribute-value={attribute.value}
                   key={attribute.name}
-                  selected={
-                    (!!this.props.selectedAttribute &&
-                      attribute.name == this.props.selectedAttribute.name) ||
-                    attribute.name == this.props.defaultAttribute
-                      ? 'selected'
-                      : ''
-                  }
                 >
                   {attribute.name}: "{attribute.value.trim()}"
                 </option>


### PR DESCRIPTION
This PR fixes an issue where React was generating a warning complaining about the use of the `selected` attribute in the `select` DOM element.

## Steps to reproduce the fixed issue
- Run the app
- Load the developer console
- Load a rule with properties e.g. `Global`
- Load an HTML page e.g. the sample article
- Type a selector that will match at least an element e.g h1, h2
- Check the developer console

## Expected result
No warnings are raised

## Actual result
The following warning is shown:
```
Warning: Use the `defaultValue` or `value` props on <select> instead of setting `selected` on <option>.
```