### PR TITLE
Fix Selector picker switching between controlled and uncontrolled behavior

### DIFF
--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -22,7 +22,7 @@ type Props = {
 type State = {
   findAttributeName?: ?string,
   findMultipleElements?: ?boolean,
-  resolvedCssSelector: ?string,
+  resolvedCssSelector: string,
   selectedElementAttributes: Array<Attribute>,
   selectedElementCount?: number,
   selector?: ?string,
@@ -33,7 +33,7 @@ class App extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      resolvedCssSelector: null,
+      resolvedCssSelector: '',
       selectedElementAttributes: [],
       rulesJSON: '{rules:[]}',
     };
@@ -75,7 +75,7 @@ class App extends React.Component<Props, State> {
     });
   };
 
-  handleBrowserCssSelectorResolved = (resolvedCssSelector: ?string) => {
+  handleBrowserCssSelectorResolved = (resolvedCssSelector: string) => {
     this.setState({
       resolvedCssSelector: resolvedCssSelector,
       selectedElementAttributes: [],

--- a/src/js/components/PropertyPicker.react.js
+++ b/src/js/components/PropertyPicker.react.js
@@ -38,7 +38,7 @@ type Props = {
   onFocus: SelectorChangedArgs => void,
   onSelectorChanged: SelectorChangedArgs => void,
   placeholder: string,
-  selector: ?string,
+  selector: string,
   selectedAttribute: Attribute
 };
 

--- a/src/js/components/RuleList.react.js
+++ b/src/js/components/RuleList.react.js
@@ -34,7 +34,7 @@ type Props = {
   onFind: (name: string, multiple: boolean) => void,
   onSelectorChanged: (selector: ?string, multiple: ?boolean) => void,
   onRulesJSONChanged: (rulesJSON: string) => void,
-  resolvedCssSelector: ?string,
+  resolvedCssSelector: string,
   rules: Array<InputRule>,
   selectedElementAttributes: Array<Attribute>,
   selectedElementCount: ?number
@@ -53,12 +53,12 @@ type RuleSettingsType = {
   class: string,
   displayName?: string,
   properties: Map<string, PropertySettings>,
-  selector: ?string
+  selector: string
 };
 
 type OutputRuleType = {
   class: string,
-  selector: ?string,
+  selector: string,
   properties: Object
 };
 
@@ -152,6 +152,7 @@ class RuleList extends React.Component<Props, State> {
         ruleSettings.properties.set(property.name, {
           ...property,
           attributes: [],
+          selector: '',
         });
       });
     }

--- a/src/js/components/RulePicker.react.js
+++ b/src/js/components/RulePicker.react.js
@@ -45,7 +45,7 @@ type Props = {
   onSelectorChanged: RuleSelectorChangedArgs => void,
   properties: Map<string, PropertySettings>,
   ruleKey: string,
-  selector: ?string
+  selector: string
 };
 
 type State = {

--- a/src/js/components/SelectorPicker.react.js
+++ b/src/js/components/SelectorPicker.react.js
@@ -22,7 +22,7 @@ type Props = {
   onFocus?: SelectorChangedArgs => void,
   onSelectorChanged: SelectorChangedArgs => void,
   placeholder?: string,
-  selector: ?string
+  selector: string
 };
 
 type State = {

--- a/src/js/types/PropertySettings.js
+++ b/src/js/types/PropertySettings.js
@@ -20,6 +20,6 @@ export type PropertySettings = {
   name: string,
   placeholder: string,
   selectedAttribute?: Attribute,
-  selector?: ?string,
+  selector: string,
   type?: string
 };


### PR DESCRIPTION
This PR fixes a warning raised by React about the mixing of controlled and uncontrolled behavior in the `SelectorPicker` component.

In short, the issue is that we are binding the value of a text input to a `null` value when we have no selector. The issue is fixed by replacing `null` with `''`. More info [here](https://reactjs.org/docs/forms.html#controlled-input-null-value).

## Steps to reproduce the fixed issue
- Run the app
- Load the developer console
- Load a rule with properties e.g. `Global`
- Set your cursor in one of the property selector fields that is empty
- Check the developer console

## Expected result
No warnings are raised

## Actual result
The following warning is shown:
```
Warning: SelectorPicker is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component.
```