### PR TITLE
Prevent overriding existing content attribute

### DIFF
--- a/src/js/injected.js
+++ b/src/js/injected.js
@@ -27,7 +27,7 @@ window.addEventListener('load', () => {
       }));
 
     attributes.push({
-      name: 'content',
+      name: 'innerContent',
       value: element.textContent,
       type: 'element', // RulePropertyTypes.ELEMENT,
     });

--- a/src/js/utils/RuleExporter.js
+++ b/src/js/utils/RuleExporter.js
@@ -100,7 +100,7 @@ class RuleExporter {
         ...((property.attribute || property.definition.defaultAttribute) !=
           null &&
         (property.attribute || property.definition.defaultAttribute) !=
-          'content' &&
+          'innerContent' &&
         (property.attribute || property.definition.defaultAttribute) !=
           'textContent'
           ? {


### PR DESCRIPTION
This PR prevents overriding the `content` attribute when it exists in a DOM element. For example in `<meta property="og:image" content="https://example.com/image.jog" />`.

I did not add any tests because the change is small, we still don't have any tests for the injected code, and I want to move fast and focus in other fixes; but if it anyone feels it is required I am happy to add tests.

## Test Plan
- Load the sample article
- Add the Global Rule (Article Structure)
- Set `html` as rule selector
- Set `meta[property="og:image"]` as selector for the Hero Image
- Verify you see the `content` attribute with the URL of the image as value