### PR TITLE
Fix multiple linter warnings

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -27,7 +27,9 @@ function createWindow() {
   } = require('electron-devtools-installer');
 
   installExtension(REACT_DEVELOPER_TOOLS)
+    // eslint-disable-next-line no-console
     .then(name => console.log(`Added Extension:  ${name}`))
+    // eslint-disable-next-line no-console
     .catch(err => console.log('An error occurred: ', err));
 
   // and load the index.html of the app.

--- a/src/js/components/Browser.react.js
+++ b/src/js/components/Browser.react.js
@@ -229,6 +229,7 @@ class Browser extends React.Component<Props, State> {
       );
       this.webview.addEventListener('dom-ready', this.highlightElements);
       this.webview.addEventListener('dom-ready', this.resetProgress);
+      // eslint-disable-next-line no-console
       this.webview.addEventListener('error', console.log.bind(console));
       this.webview.addEventListener(
         'ipc-message',

--- a/src/js/components/DateTimeFormatPicker.react.js
+++ b/src/js/components/DateTimeFormatPicker.react.js
@@ -11,7 +11,6 @@
 const React = require('react');
 const classNames = require('classnames');
 const moment = require('moment');
-import type { Attribute } from '../models/Attribute';
 import type { RuleProperty } from '../models/RuleProperty';
 import type { Props as BaseProps } from '../containers/AppContainer.react';
 import RuleActions from '../data/RuleActions';

--- a/src/js/components/RuleList.react.js
+++ b/src/js/components/RuleList.react.js
@@ -16,13 +16,8 @@ const Fs = require('fs');
 
 import { RuleFactory } from '../models/Rule';
 import RuleExporter from '../utils/RuleExporter';
-import type { Rule } from '../models/Rule';
 import type { Props } from '../containers/AppContainer.react';
-import {
-  SortableContainer,
-  SortableElement,
-  arrayMove,
-} from 'react-sortable-hoc';
+import { SortableContainer, SortableElement } from 'react-sortable-hoc';
 
 const dialogDefaultPath = 'rules.json';
 const dialogFilter = {

--- a/src/js/components/SelectorPicker.react.js
+++ b/src/js/components/SelectorPicker.react.js
@@ -12,10 +12,6 @@ const React = require('react');
 
 import RuleActions from '../data/RuleActions';
 import EditorActions from '../data/EditorActions';
-import type { Rule } from '../models/Rule';
-import { RuleFactory } from '../models/Rule';
-import { RulePropertyFactory } from '../models/RuleProperty';
-import type { RuleProperty } from '../models/RuleProperty';
 import type { Props as BaseProps } from '../containers/AppContainer.react';
 import type { Field } from '../models/Field';
 

--- a/src/js/components/__tests__/RuleList.react-test.js
+++ b/src/js/components/__tests__/RuleList.react-test.js
@@ -14,7 +14,6 @@ const Enzyme = require('enzyme');
 const { mount } = Enzyme;
 
 const React = require('react');
-const RuleList = require('../RuleList.react.js');
 
 // Rules that are always included in the exported file
 const defaultExportedRules = [{ class: 'TextNodeRule' }];
@@ -24,8 +23,6 @@ const RULE_HEADER_SELECTOR = 'h2.rule-header';
 import { RuleDefinitionFactory } from '../../models/RuleDefinition';
 import { RulePropertyDefinitionFactory } from '../../models/RulePropertyDefinition';
 import RuleDefinitionActions from '../../data/RuleDefinitionActions';
-import type { Rule } from '../../models/Rule';
-import type { RuleDefinition } from '../../models/RuleDefinition';
 import { Map } from 'immutable';
 import AppContainer from '../../containers/AppContainer.react';
 
@@ -339,8 +336,4 @@ function testImportedFileResult(inputRules, importedRules, expectCallback) {
 
   // Trigger the verification callback passing the mounted component
   expectCallback(component);
-}
-
-function inputRulesToMap(inputRules) {
-  return new Map(inputRules.map(inputRule => [inputRule.class, inputRule]));
 }

--- a/src/js/data/EditorStore.js
+++ b/src/js/data/EditorStore.js
@@ -11,10 +11,7 @@
 import { ReduceStore } from 'flux/utils';
 const RulesEditorDispatcher = require('./RulesEditorDispatcher.js');
 
-import { Record, Map } from 'immutable';
-import type { RecordOf, RecordFactory } from 'immutable';
-import type { RuleProperty } from '../models/RuleProperty';
-import type { Rule } from '../models/Rule';
+import { Map } from 'immutable';
 import type { Field } from '../models/Field';
 
 import EditorActionTypes from './EditorActionTypes.js';

--- a/src/js/data/RuleActions.js
+++ b/src/js/data/RuleActions.js
@@ -10,7 +10,6 @@
 
 const RulesEditorDispatcher = require('./RulesEditorDispatcher.js');
 import type { Rule } from '../models/Rule';
-import type { RuleProperty } from '../models/RuleProperty';
 import type { Field } from '../models/Field';
 
 import RuleActionTypes from './RuleActionTypes.js';

--- a/src/js/data/RuleStore.js
+++ b/src/js/data/RuleStore.js
@@ -11,11 +11,8 @@
 const Immutable = require('immutable');
 const RulesEditorDispatcher = require('./RulesEditorDispatcher.js');
 
-import EditorActions from './EditorActions';
 import { ReduceStore } from 'flux/utils';
 import RuleActionTypes from './RuleActionTypes.js';
-import { RuleFactory } from '../models/Rule';
-import { RulePropertyFactory } from '../models/RuleProperty';
 import type { Rule } from '../models/Rule';
 import type { Field } from '../models/Field';
 import type { RuleActionType } from './RuleActionTypes.js';

--- a/src/js/data/__tests__/RuleStore.test.js
+++ b/src/js/data/__tests__/RuleStore.test.js
@@ -6,9 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { OrderedMap, List } from 'immutable';
 import RuleStore from '../RuleStore';
-import RuleActionTypes from '../RuleActionTypes';
 import RuleActions from '../RuleActions';
 import { RuleFactory } from '../../models/Rule';
 

--- a/src/js/injected.js
+++ b/src/js/injected.js
@@ -44,7 +44,6 @@ window.addEventListener('load', () => {
   let previousHoveredElement;
   let selectingElement = false;
   let selectingMultipleElements = false;
-  let selectedElementSubscriberWindow;
 
   document.addEventListener('mouseover', handleMouseOver, false);
   document.addEventListener('click', handleClick, false);
@@ -53,11 +52,6 @@ window.addEventListener('load', () => {
     if (event.method == 'highlightElements') {
       document.body.classList.remove(
         'facebook-instant-articles-sdk-rules-editor-highlight-mode'
-      );
-      let elements = highlightElements(
-        event.selector,
-        event.source,
-        !!event.multiple
       );
     } else if (event.method == 'selectElement') {
       selectingElement = true;

--- a/src/js/models/Attribute.js
+++ b/src/js/models/Attribute.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import { Record, Set } from 'immutable';
+import { Record } from 'immutable';
 import type { RecordOf, RecordFactory } from 'immutable';
 import type { RulePropertyType } from './RulePropertyTypes';
 import RulePropertyTypes from './RulePropertyTypes';

--- a/src/js/models/Editor.js
+++ b/src/js/models/Editor.js
@@ -9,8 +9,6 @@
  */
 
 import { Map, Record } from 'immutable';
-import type { Rule } from './Rule';
-import type { RuleProperty } from './RuleProperty';
 import type { Attribute } from '../models/Attribute';
 import type { Field } from './Field';
 import type { RecordOf, RecordFactory } from 'immutable';

--- a/src/js/models/Field.js
+++ b/src/js/models/Field.js
@@ -8,9 +8,6 @@
  * @flow
  */
 
-import { Record } from 'immutable';
-import { RuleFactory } from './Rule';
-import { RulePropertyFactory } from './RuleProperty';
 import type { Rule } from './Rule';
 import type { RuleProperty } from './RuleProperty';
 

--- a/src/js/models/Rule.js
+++ b/src/js/models/Rule.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import { Record, Map, Seq } from 'immutable';
+import { Record, Map } from 'immutable';
 import { RuleDefinitionFactory } from './RuleDefinition.js';
 import { RulePropertyFactory } from './RuleProperty';
 import { RulePropertyUtils } from './RuleProperty';

--- a/src/js/models/__tests__/RuleProperty.test.js
+++ b/src/js/models/__tests__/RuleProperty.test.js
@@ -8,7 +8,6 @@
 
 import { RulePropertyUtils } from '../RuleProperty';
 import { RulePropertyFactory } from '../RuleProperty';
-import { RulePropertyDefinitionFactory } from '../RulePropertyDefinition';
 import RulePropertyTypes from '../RulePropertyTypes';
 
 describe('RulePropertyUtils', () => {

--- a/src/js/rule-definitions.js
+++ b/src/js/rule-definitions.js
@@ -11,7 +11,6 @@
 import { Map, Set } from 'immutable';
 import RulePropertyTypes from './models/RulePropertyTypes.js';
 import type { RuleDefinition } from './models/RuleDefinition';
-import type { RulePropertyDefinition } from './models/RulePropertyDefinition';
 import { RuleDefinitionFactory } from './models/RuleDefinition';
 import { RulePropertyDefinitionFactory } from './models/RulePropertyDefinition';
 import { RulePropertyFactory } from './models/RuleProperty';

--- a/src/js/utils/RuleExporter.js
+++ b/src/js/utils/RuleExporter.js
@@ -80,6 +80,7 @@ class RuleExporter {
         ...(properties != null ? { properties } : {}),
       };
     }
+    return null;
   }
 
   static createJSONFromRuleProperties(
@@ -92,6 +93,7 @@ class RuleExporter {
         .filter(Boolean)
         .toJSON();
     }
+    return null;
   }
 
   static createJSONFromRuleProperty(property: RuleProperty): ?RulePropertyJSON {
@@ -119,6 +121,7 @@ class RuleExporter {
             : property.definition.defaultType,
       };
     }
+    return null;
   }
 
   static createRuleFromJSON(
@@ -135,6 +138,7 @@ class RuleExporter {
         ),
       });
     }
+    return null;
   }
 
   static createRulePropertiesFromJSON(
@@ -169,6 +173,7 @@ class RuleExporter {
         type: rulePropertyJSON.type,
       });
     }
+    return null;
   }
 }
 

--- a/src/js/utils/debounce.js
+++ b/src/js/utils/debounce.js
@@ -18,8 +18,8 @@
 function debounce(func, wait, immediate = false) {
   let timeout;
   return function() {
-    var context = this,
-      args = arguments;
+    var context = this;
+    var args = arguments;
     var later = function() {
       timeout = null;
       if (!immediate) {

--- a/src/js/utils/resolve-css-selector.js
+++ b/src/js/utils/resolve-css-selector.js
@@ -270,10 +270,8 @@ function getScore(candidate) {
  * @returns {string} A full path CSS selector for the given element in the document.
  */
 var resolveAbsoluteCSSSelector = function(element) {
-  var document = element.ownerDocument;
-
   if (!(element instanceof Element)) {
-    return;
+    return null;
   }
   let path = [];
   while (element.nodeType === Node.ELEMENT_NODE) {
@@ -282,8 +280,8 @@ var resolveAbsoluteCSSSelector = function(element) {
       selector = '#' + element.id;
     } else {
       let foundSameNodeNameSibling = false;
-      let sib = element,
-        nth = 1;
+      let sib = element;
+      let nth = 1;
       while (
         sib.nodeType === Node.ELEMENT_NODE &&
         (sib = sib.previousElementSibling)


### PR DESCRIPTION
This PR removes multiple linter warnings, mostly about unused variables.

I left untouched those about exceeding the maximum line length since it is happening mostly on comments and imports; which we can discuss how to solve.

## Test Plan
```node_modules/.bin/eslint --fix "src/**/*.js"```

Expected to get 30 warnings about exceeding max length 2 for `jsx-a11y/no-noninteractive-element-interactions` (32 in total).