### PR TITLE
Restore missing highlightElements call

### DIFF
--- a/src/js/injected.js
+++ b/src/js/injected.js
@@ -53,6 +53,7 @@ window.addEventListener('load', () => {
       document.body.classList.remove(
         'facebook-instant-articles-sdk-rules-editor-highlight-mode'
       );
+      highlightElements(event.selector, event.source, !!event.multiple);
     } else if (event.method == 'selectElement') {
       selectingElement = true;
       selectingMultipleElements = !!event.multiple;


### PR DESCRIPTION
This PR restores a call to the `highlightElements` that I removed by mistake in #44 when removing an unused variable.