### PR TITLE
Add Related Item rule

### DIFF
--- a/src/js/rule-definitions.js
+++ b/src/js/rule-definitions.js
@@ -232,6 +232,24 @@ ruleDefinitions.push(
 );
 ruleDefinitions.push(
   RuleDefinitionFactory({
+    name: 'RelatedItemRule',
+    displayName: 'Related Item',
+    placeholder: 'Example: li',
+    properties: Map({
+      'related.url': RulePropertyDefinitionFactory({
+        name: 'related.url',
+        displayName: 'URL',
+        placeholder: 'Example: a',
+        supportedTypes: Set([RulePropertyTypes.STRING]),
+        defaultType: RulePropertyTypes.STRING,
+        defaultAttribute: 'href',
+        required: true,
+      }),
+    }),
+  })
+);
+ruleDefinitions.push(
+  RuleDefinitionFactory({
     name: 'ImageRule',
     displayName: 'Image',
     placeholder: 'Example: img',


### PR DESCRIPTION
This PR adds the Related Item rule, which was missing and preventing related articles to be added to the IA markup.

## Test Plan
- You can use the following URL as a sample article: https://www.berkeleyside.com/2018/01/23/judge-allows-berkeley-homeless-group-sue-city-dismisses-case-bart/
- *Pass Through*: `div.meta-related-stories`
- Use `ul` as the selector for *Related Articles* rule
  - Leave blank the title optional property. We need to investigate why it is not picking it up
- Use `li` as the selector for *Related Item* rule and `a` for the selector of the URL property

You should see the related articles element (`ul.op-related-articles`) in the rendered IA markup:

![image](https://user-images.githubusercontent.com/18663703/35400692-79f792aa-01c5-11e8-818d-b59e16c491ea.png)
