### PR TITLE
Fix canonical URL property name

### DIFF
--- a/src/js/rule-definitions.js
+++ b/src/js/rule-definitions.js
@@ -72,8 +72,8 @@ ruleDefinitions.push(
         required: true,
         unique: true,
       }),
-      'article.url': RulePropertyDefinitionFactory({
-        name: 'article.url',
+      'article.canonical': RulePropertyDefinitionFactory({
+        name: 'article.canonical',
         displayName: 'Article URL',
         placeholder: 'Example: link[rel=canonical]',
         defaultAttribute: 'href',


### PR DESCRIPTION
This PR fixes an issue where the canonical URL was not rendered correctly because the property definition had the wrong name.

## Test Plan
- Load the sample article
- Add the **Article Structure** rule and fill out all the required properties (no need to change the selector for canonical URL)
- Verify the generated IA markup has the canonical URL