### PR TITLE
Made published date optional

### DIFF
--- a/src/js/rule-definitions.js
+++ b/src/js/rule-definitions.js
@@ -42,7 +42,6 @@ ruleDefinitions.push(
         supportedTypes: Set([RulePropertyTypes.DATETIME]),
         defaultType: RulePropertyTypes.DATETIME,
         unique: true,
-        required: true,
       }),
       'author.name': RulePropertyDefinitionFactory({
         name: 'author.name',


### PR DESCRIPTION
This PR changes the published date property of the GlobalRule to be optional, as the OG ingestion is already setting a default date if it's not present.