### PR TITLE
Add Credit property to Image rule

### DIFF
--- a/src/js/rule-definitions.js
+++ b/src/js/rule-definitions.js
@@ -295,6 +295,14 @@ ruleDefinitions.push(
         defaultType: RulePropertyTypes.ELEMENT,
         defaultAttribute: 'content',
       }),
+      'image.credit': RulePropertyDefinitionFactory({
+        name: 'image.credit',
+        displayName: 'Credit',
+        placeholder: 'Example: cite',
+        supportedTypes: Set([RulePropertyTypes.ELEMENT]),
+        defaultType: RulePropertyTypes.ELEMENT,
+        defaultAttribute: 'content',
+      }),
     }),
   })
 );


### PR DESCRIPTION
This PR adds the `Credit` property to the `Image` rule.

## Test Plan
Generate an image with caption and credits.

### Example
- URL: http://www.civilbeat.org/2018/01/why-hawaiis-unlicensed-elder-care-industry-is-out-of-control/
- **Image Rule**:
  - Selector: div.cb-image
  - URL property: img
    - Attribute: src
  - Caption property: p.wp-caption-text
    - Attribute: content
  - **Credit property**: p.wp-caption-source
    - Attribute: content


### Expected Result
The generated Image element should have the following structure:

```html
<figure>
  <img .../>
  <figcaption>
    <cite>...<cite/>
  </figcation>
</figure>
```