### PR TITLE
Migrate from componentWill* to componentDid*

### DIFF
--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -25,7 +25,7 @@ class App extends React.Component<Props> {
     document.addEventListener('keyup', this.cancelOnEscape);
     document.addEventListener('click', this.blurOnClickOut);
   }
-  componentWillUnmount() {
+  componentDidUnmount() {
     document.removeEventListener('keyup', this.cancelOnEscape);
     document.removeEventListener('click', this.blurOnClickOut);
   }

--- a/src/js/components/SelectorPicker.react.js
+++ b/src/js/components/SelectorPicker.react.js
@@ -57,7 +57,7 @@ class SelectorPicker extends React.Component<Props, State> {
     this.configureLine();
   }
 
-  componentWillUnmount() {
+  componentDidUnmount() {
     this.disableMouseMoveTracking();
   }
 


### PR DESCRIPTION
Due to the new React Fiber architecture all componentWill* lifecycle hooks will be deprecated in the near future. This PR migrate the code from componentWill* to componentDid*.

If anyone wants a challenging project to hack on they could implement an ESLint rule to forbid componentWill* hooks.