### PR TITLE
Improve visuals based on new logo

### DIFF
--- a/src/css/home.css
+++ b/src/css/home.css
@@ -43,7 +43,7 @@ li span {
   font-size: 0.5em;
   text-align: center;
 }
+
 img.logo {
-  opacity: 0.1;
-  padding: 5px;
+  opacity: 0.3;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -654,6 +654,9 @@ button {
   background-color: #3b5998 !important;
   color: white !important;
 }
+.nux-header img {
+  margin-top: -7px;
+}
 .nux-modal {
   background: none !important;
 }
@@ -698,4 +701,9 @@ a:hover {
 /* Disable Filtering */
 .rule-filters {
   display: none;
+}
+
+header > img.logo {
+  opacity: 1;
+  margin: 10px;
 }

--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -63,7 +63,12 @@ class App extends React.Component<Props> {
             <NUX {...this.props} />
             <BugReporter {...this.props} />
           </div>
-          <img src="../img/icon-nobg.svg" width="48" height="48" />
+          <img
+            src="../img/icon-nobg.svg"
+            width="48"
+            height="48"
+            className="logo"
+          />
           <h1>
             <span className="ia">Instant Articles</span>{' '}
             <span className="app-name">Builder</span>


### PR DESCRIPTION
This PR:

- [x] Fixes the header padding around the logo
- [x] Fixes the margin around the logo on the welcome screen
- [x] Corrects logo and logo alignment on preview
- [x] Replaces logo and get started docs on GH site.

<img width="1552" alt="welcome" src="https://user-images.githubusercontent.com/1878108/40693159-42ef6c28-638c-11e8-9fd5-334bc0d364a7.png">
<img width="1552" alt="header" src="https://user-images.githubusercontent.com/1878108/40693160-4325e3d4-638c-11e8-8fd5-f28a20db5094.png">
