### PR TITLE
Fix import and export functions

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -25,9 +25,21 @@ const electron = {
     // Replace the function we will use in the dialog object
     dialog: {
       // Call directly the callback function passing a single valid file name
-      showOpenDialog: (options, callback) => callback([FILE_NAME]),
+      showOpenDialog: (options) => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            filePaths: [FILE_NAME],
+          });
+        });
+      },
       // Call directly the callback function passing a valid file name
-      showSaveDialog: (options, callback) => callback(FILE_NAME),
+      showSaveDialog: (options) => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            filePath: FILE_NAME,
+          });
+        });
+      },
     },
   },
 };

--- a/src/js/components/FileTools.react.js
+++ b/src/js/components/FileTools.react.js
@@ -9,7 +9,9 @@
  */
 
 const React = require('react');
-const { remote: { dialog: Dialog } } = require('electron');
+const {
+  remote: { dialog: Dialog },
+} = require('electron');
 const Fs = require('fs');
 const path = require('path');
 
@@ -40,41 +42,35 @@ class FileTools extends React.Component<Props> {
   };
 
   handleExport = () => {
-    Dialog.showSaveDialog(
-      {
-        defaultPath: dialogDefaultPath,
-        filters: [dialogFilter],
-      },
-      fileName => {
-        if (fileName) {
-          const contents = JSON.stringify(
-            RuleExporter.export(this.props.rules, this.props.settings)
-          );
-          Fs.writeFile(fileName, contents, importExportEncoding, error => {
-            if (error) {
-              Dialog.showErrorBox('Unable to save file', error);
-            }
-          });
-        }
+    Dialog.showSaveDialog({
+      defaultPath: dialogDefaultPath,
+      filters: [dialogFilter],
+    }).then((e: { filePath: string }) => {
+      if (e.filePath) {
+        const contents = JSON.stringify(
+          RuleExporter.export(this.props.rules, this.props.settings)
+        );
+        Fs.writeFile(e.filePath, contents, importExportEncoding, error => {
+          if (error) {
+            Dialog.showErrorBox('Unable to save file', error);
+          }
+        });
       }
-    );
+    });
   };
 
   handleImport = () => {
-    Dialog.showOpenDialog(
-      {
-        defaultPath: dialogDefaultPath,
-        filters: [dialogFilter],
-        properties: ['openFile'],
-      },
-      (filePaths: Array<string>) => {
-        if (filePaths && filePaths.length === 1) {
-          Fs.readFile(filePaths[0], importExportEncoding, (error, data) => {
-            this.loadFromExportedData(data);
-          });
-        }
+    Dialog.showOpenDialog({
+      defaultPath: dialogDefaultPath,
+      filters: [dialogFilter],
+      properties: ['openFile'],
+    }).then((e: { filePaths: Array<string> }) => {
+      if (e.filePaths.length === 1) {
+        Fs.readFile(e.filePaths[0], importExportEncoding, (error, data) => {
+          this.loadFromExportedData(data);
+        });
       }
-    );
+    });
   };
 
   handleNew = () => {


### PR DESCRIPTION
This PR fixes the import and export features of the tool, which got broken with the upgrade of Electron, as the `showSaveDialog` and `showOpenDialog` functions now return promises.

The main changes in this PR are switching from callback functions to promises. The code that gets executed after the promise is resolved is the same that was executed inside the callbacks.

I tweaked the test that should have caught the issue, but also you can run and end to end test as follows:

1. Start the tool
1. Make some changes to some selectors
1. Save the rules
1. Click on the New button to clear the changes you made to the selectors
1. Load the file you saved

Expected result: You should be able to load the files (it was saved) and the changes you made are loaded to the correct fields.