### PR TITLE
Add website Legal section

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -57,6 +57,21 @@ class Footer extends React.Component {
               License
             </a>
           </div>
+          <div>
+            <h5>Legal</h5>
+            <a
+              href="https://opensource.facebook.com/legal/privacy/"
+              target="blank"
+              rel="noreferrer noopener">
+              Privacy
+            </a>
+            <a
+              href="https://opensource.facebook.com/legal/terms/"
+              target="blank"
+              rel="noreferrer noopener">
+              Terms
+            </a>
+          </div>
         </section>
 
         <a


### PR DESCRIPTION
This PR adds a new section to the footer of [the website](https://facebook.github.io/instant-articles-builder/) that we publish to Github pages. I am adding a couple of links to point to the Privacy Policy and Terms of Use.

You can test this locally by navigating to the `website` folder and running:

```
npm install && npm start
```

Then you can check locally the changes by opening `http://localhost:3000` (which is provided by Docusaurus).

![image](https://user-images.githubusercontent.com/18663703/107550791-757c8900-6b9f-11eb-938f-921aab4df391.png)
