### PR TITLE
Updated displayName of href property [#90]

### DIFF
--- a/src/js/rule-definitions.js
+++ b/src/js/rule-definitions.js
@@ -136,7 +136,7 @@ ruleDefinitions.push(
     properties: Map({
       'anchor.href': RulePropertyDefinitionFactory({
         name: 'anchor.href',
-        displayName: 'HRef',
+        displayName: 'URL',
         placeholder: 'Example: a',
         supportedTypes: Set([RulePropertyTypes.STRING]),
         defaultType: RulePropertyTypes.STRING,


### PR DESCRIPTION
According with the discussion from #90 , the defaultName of "HRef" can be updated to "URL" in the Link section.

**Before**
<img width="340" alt="Screen Shot 2021-02-18 at 17 38 30" src="https://user-images.githubusercontent.com/78859914/108418520-21f9e300-7210-11eb-816a-8d95b35411c0.png">

**After:**
<img width="348" alt="Screen Shot 2021-02-18 at 16 31 15" src="https://user-images.githubusercontent.com/78859914/108418529-258d6a00-7210-11eb-8b9f-c52cf1e03235.png">
