### PR TITLE
Add support for webserver with cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ docker run -it --rm -p 8105:8000 --name ia-webserver ia-webserver:latest
 
 #### Docker-compose (with cache)
 
+Update .env with the port according with docker-compose file. As default, memcache it is configured: "8107:8000".
+
 You can get a webserver with cache (using [memcached](https://memcached.org/)) by running the following command from the `Docker/webserver/ folder:
 
 ```

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ IA_BUILDER_PREVIEW_WEBSERVER_PORT=8105
 
 You can use the [Docker](https://www.docker.com/) image included in this repo under `docker/webserver` to get a webserver instance running locally in Docker.
 
-Run the following command to build the image:
+#### Single container (no cache)
+
+You can get a single container with the webserver without cache by running the following command to build the image:
 
 ```
 docker build ./docker/webserver -t ia-webserver
@@ -83,6 +85,22 @@ and then the following command to run your container and make it accessible thro
 
 ```
 docker run -it --rm -p 8105:8000 --name ia-webserver ia-webserver:latest
+```
+
+#### Docker-compose (with cache)
+
+You can get a webserver with cache (using [memcached](https://memcached.org/)) by running the following command from the `Docker/webserver/ folder:
+
+```
+docker-compose up
+```
+
+You can take a look at the cache stats by going to http://localhost:11212.
+
+once you are done you can stop both containers with the following command:
+
+```
+docker-compose down
 ```
 
 ## License

--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -1,24 +1,28 @@
-ARG PHP_IMAGE=7.2-alpine
-FROM php:${PHP_IMAGE}
+FROM php:7.4.16-cli
 
-# Install git
-RUN apk update
-RUN apk add git
+ARG GIT_BRANCH=feature/webserver-cache
 
-# Install composer
-RUN apk add composer
+RUN apt-get update && apt-get install -y libmemcached-dev zlib1g-dev \
+    && pecl install memcached-3.1.5 \
+    && docker-php-ext-enable memcached
+
+RUN apt-get install -y git wget
 
 EXPOSE 8000
 
-WORKDIR /ia-builder
+WORKDIR /
+
+# Install composer
+RUN wget -O composer-setup.php https://getcomposer.org/installer && \
+    php composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm composer-setup.php
 
 # Clone Instant Articles Builder GitHub repo
-RUN git clone https://github.com/facebook/instant-articles-builder.git
+RUN git clone https://github.com/facebook/instant-articles-builder.git && \
+    cd instant-articles-builder && \
+    git checkout ${GIT_BRANCH}
 
-WORKDIR /app
-
-# Copy all contents from the webserver folder in the IA repo to our current dir
-RUN cp -R /ia-builder/instant-articles-builder/webserver/* ./
+WORKDIR /instant-articles-builder/webserver
 
 # Install IA Builder webserver dependencies
 RUN composer install

--- a/docker/webserver/docker-compose.yml
+++ b/docker/webserver/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  memcached:
+    image: memcached:1.4
+    ports:
+      - "11211:11211"
+
+  ia_webserver_memcached:
+    build: .
+    ports:
+      - "8107:8000"
+    links:
+      - memcached
+    container_name: ia-webserver-memcached
+
+  memcached_ui:
+    image: alphayax/phpmemcachedadmin
+    ports:
+      - "11212:80"
+    volumes:
+      - ./memcached-ui.config.php:/var/www/html/Config/Memcache.php
+    links:
+      - memcached
+    container_name: memcached-ui

--- a/docker/webserver/memcached-ui.config.php
+++ b/docker/webserver/memcached-ui.config.php
@@ -1,0 +1,28 @@
+<?php
+return array (
+  'stats_api' => 'Server',
+  'slabs_api' => 'Server',
+  'items_api' => 'Server',
+  'get_api' => 'Server',
+  'set_api' => 'Server',
+  'delete_api' => 'Server',
+  'flush_all_api' => 'Server',
+  'connection_timeout' => '1',
+  'max_item_dump' => '100',
+  'refresh_rate' => 2,
+  'memory_alert' => '80',
+  'hit_rate_alert' => '90',
+  'eviction_alert' => '0',
+  'file_path' => 'Temp/',
+  'servers' =>
+  array (
+    'Default' =>
+    array (
+      'memcached:11211' =>
+      array (
+        'hostname' => 'memcached',
+        'port' => '11211',
+      ),
+    ),
+  ),
+);

--- a/webserver/article.php
+++ b/webserver/article.php
@@ -7,26 +7,63 @@ use Facebook\InstantArticles\Elements\InstantArticle;
 use Facebook\InstantArticles\Elements\Header;
 use Facebook\InstantArticles\AMP\AMPArticle;
 
+$mc;
+
+define("CACHE_KEY_TYPE_IA", "ia");
+define("CACHE_KEY_TYPE_AMP", "amp");
+define("CACHE_KEY_TYPE_URL", "url");
+define("CACHE_KEY_TYPE_WARNINGS", "warnings");
+
+define("CACHE_KEY_HASH_ALGO", "sha256");
+
 function exception_error_handler($errno, $errstr, $errfile, $errline ) {
   // noop
 }
 
-set_error_handler("exception_error_handler");
-
-try {
-  // Read the URL parameter
-  //----------------------
-  $url = $_GET['url'];
-  $rules = $_POST['rules'];
-
-
-  if ((!$url || !$rules) || (filter_var($url, FILTER_VALIDATE_URL) === FALSE)) {
-    $response->error = invalidIA();
-    header('Content-type: application/json');
-    echo json_encode($response);
-    die();
+function try_init_cache() {
+  if (class_exists(Memcached)) {
+    global $mc;
+    $mc = new Memcached();
+    $mc->addServer("memcached", 11211);
   }
+}
 
+function try_get_cached_value($key, $cache_type) {
+  if (!class_exists(Memcached))
+    return null;
+
+  // Need to create a valid key for memcached
+  $hashed_key = hash(CACHE_KEY_HASH_ALGO, $cache_type . ": " . $key, false);
+
+  global $mc;
+  $value = $mc->get($hashed_key);
+  if (!$value)
+    return null;
+
+  return $value;
+}
+
+function try_set_cached_value($key, $value, $cache_type){
+  if (!class_exists(Memcached))
+    return;
+
+  // Need to use a valid key for memcached
+  $hashed_key = hash(CACHE_KEY_HASH_ALGO, $cache_type . ": " . $key, false);
+
+  global $mc;
+  $mc->set($hashed_key, $value);
+}
+
+function get_html_markup($url) {
+  $cache_key = $url;
+
+  $possible_html_markup = try_get_cached_value($cache_key, CACHE_KEY_TYPE_URL);
+
+  // Cache hit
+  if (!is_null($possible_html_markup))
+    return $possible_html_markup;
+
+  // Cache miss
   $context_options = stream_context_create(array(
     "ssl"=>array(
         "verify_peer"=>false,
@@ -41,7 +78,21 @@ try {
   //--------------
   $content = file_get_contents($url, false, $context_options);
 
+  try_set_cached_value($cache_key, $content, CACHE_KEY_TYPE_URL);
 
+  return $content;
+}
+
+function get_instant_article($html_markup, $url, $rules) {
+  $cache_key = $rules . $url;
+
+  $possible_instant_article = try_get_cached_value($cache_key, CACHE_KEY_TYPE_IA);
+
+  // Cache hit
+  if (!is_null($possible_instant_article))
+    return $possible_instant_article;
+
+  // Cache miss
   // Load rules
   //-----------
   $transformer = new Transformer();
@@ -50,41 +101,83 @@ try {
   // Transform
   //----------
   $instant_article = InstantArticle::create();
-  $transformer->transformString($instant_article, $content);
+  $transformer->transformString($instant_article, $html_markup);
 
   $warnings = $transformer->getWarnings();
 
   $string_func = function($warning) {
     return $warning->__toString();
   };
-  $response->warnings = array_map($string_func, $warnings);
+  $warnings = array_map($string_func, $warnings);
 
+  try_set_cached_value($cache_key, $warnings, CACHE_KEY_TYPE_WARNINGS);
+
+  try_set_cached_value($cache_key, $instant_article, CACHE_KEY_TYPE_IA);
+
+  return $instant_article;
+}
+
+function get_amp_markup($instant_article, $url, $rules) {
+  $cache_key = $rules . $url;
+
+  $possible_amp_markup = try_get_cached_value($cache_key, CACHE_KEY_TYPE_AMP);
+
+  // Cache hit
+  if (!is_null($possible_amp_markup))
+    return $possible_amp_markup;
+
+  // Cache miss
   $properties = array(
     'styles-folder' => __DIR__.'/styles/' // Where the styles are stored
   );
 
+  $amp_article = AMPArticle::create($instant_article, $properties);
+  $amp_article->getObserver()->addFilter(
+    'AMP_HEAD',
+    function ($head) {
+      $style_node = $head->ownerDocument->createElement('link');
+      $style_node->setAttribute('rel', 'stylesheet');
+      $style_node->setAttribute('href', 'style.css');
+      $head->appendChild($style_node);
+      return $head;
+    }
+  );
+
+  $amp_markup = $amp_article->render();
+
+  try_set_cached_value($cache_key, $amp_markup, CACHE_KEY_TYPE_AMP);
+
+  return $amp_markup;
+}
+
+set_error_handler("exception_error_handler");
+
+try_init_cache();
+
+try {
+  // Read the URL parameter
+  //----------------------
+  $url = $_GET['url'];
+  $rules = $_POST['rules'];
+
+  if (!$url || !$rules || filter_var($url, FILTER_VALIDATE_URL) === FALSE) {
+    $response->error = invalidIA();
+    header('Content-type: application/json');
+    echo json_encode($response);
+    die();
+  }
+
+  $html_markup = get_html_markup($url);
+  $instant_article = get_instant_article($html_markup, $url, $rules);
+
   if ($instant_article->isValid()) {
-    $amp_article = AMPArticle::create($instant_article, $properties);
-    $amp_article->getObserver()->addFilter(
-      'AMP_HEAD',
-      function ($head) {
-        $style_node = $head->ownerDocument->createElement('link');
-        $style_node->setAttribute('rel', 'stylesheet');
-        $style_node->setAttribute('href', 'style.css');
-        $head->appendChild($style_node);
-        return $head;
-      }
-    );
+    $amp_markup = get_amp_markup($instant_article, $url, $rules);
 
-    $amp_article = $amp_article->render();
-
-    $response->source = $instant_article->render(null, true);
-
-    if ($amp_article) {
+    if ($amp_markup) {
       $response->amp = $amp_article;
     }
-  }
-  else {
+
+  } else {
     $response->error = invalidIA();
   }
 

--- a/webserver/article.php
+++ b/webserver/article.php
@@ -83,7 +83,7 @@ function get_html_markup($url) {
   return $content;
 }
 
-function get_instant_article($html_markup, $url, $rules) {
+function get_instant_article($html_markup, $url, $rules, &$response) {
   $cache_key = $rules . $url;
 
   $possible_instant_article = try_get_cached_value($cache_key, CACHE_KEY_TYPE_IA);
@@ -109,6 +109,7 @@ function get_instant_article($html_markup, $url, $rules) {
     return $warning->__toString();
   };
   $warnings = array_map($string_func, $warnings);
+  $response->warnings = $warnings;
 
   try_set_cached_value($cache_key, $warnings, CACHE_KEY_TYPE_WARNINGS);
 
@@ -168,13 +169,15 @@ try {
   }
 
   $html_markup = get_html_markup($url);
-  $instant_article = get_instant_article($html_markup, $url, $rules);
+
+  $instant_article = get_instant_article($html_markup, $url, $rules, $response);
+  $response->source = $instant_article->render(null, true);
 
   if ($instant_article->isValid()) {
     $amp_markup = get_amp_markup($instant_article, $url, $rules);
 
     if ($amp_markup) {
-      $response->amp = $amp_article;
+      $response->amp = $amp_markup;
     }
 
   } else {


### PR DESCRIPTION
This PR is the first of a series aimed at optimize the way the preview webserver works. In this one, I am adding a cache that removes the need to perform certain repetitive operations like:

- Fetching the HTML source of the page being transformed to Instant Articles.
- Creating an Instant Article object from the rules and source HTML.
- Generating the markup used for preview (using AMP) of a given Instant Article.
- Retrieving the transformation warnings for a given URL and a set of rules.

The approach I took is that the webserver should continue to work even if the chosen cache infra (memcached) is not available. That means that for the local webserver the local cache is not expected to be used (unless you have the Memcached php client installed locally and have a server available with the name `memcached`) but that a remote webserver could benefit from using cache.

I am including a set of Docker containers (which you can run using `docker-compose`) that provide a webserver, a memcached server, and a web UI to get stats and even send commands to the memcached server.

In this PR I am only modifying the `preview.php` file, since @nataliemt already worked on #162 to get the webserver to return a JSON response that can be used.

Note: I need to rebase.