### PR TITLE
Change default branch for webserver

### DIFF
--- a/docker/webserver/Dockerfile
+++ b/docker/webserver/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.4.16-cli
 
-ARG GIT_BRANCH=feature/webserver-cache
+ARG GIT_BRANCH=master
 
 RUN apt-get update && apt-get install -y libmemcached-dev zlib1g-dev \
     && pecl install memcached-3.1.5 \

--- a/docker/webserver/docker-compose.yml
+++ b/docker/webserver/docker-compose.yml
@@ -6,7 +6,10 @@ services:
       - "11211:11211"
 
   ia_webserver_memcached:
-    build: .
+    build:
+      context: .
+      args:
+        GIT_BRANCH: master
     ports:
       - "8107:8000"
     links:


### PR DESCRIPTION
This PR replaces the default branch used to build the webserver, now that the one we were using is merged to master.