### PR TITLE
Implementation of the selector highlight for the warnings

### DIFF
--- a/src/css/injected.css
+++ b/src/css/injected.css
@@ -18,3 +18,7 @@
   cursor: pointer !important;
   box-shadow: 0px 0px 0px 1px #4a90e2, 0px 0px 4px 4px #ccc !important;
 }
+
+.facebook-instant-articles-builder-warning {
+  box-shadow: 0px 0px 0px 1px #e76e63, 0px 0px 4px 4px #ccc !important;
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -416,6 +416,18 @@ h1 {
   max-width: 300px;
 }
 
+.warning {
+  cursor: pointer;
+}
+
+.warning:hover {
+  text-decoration: underline;
+}
+
+.warning.active {
+  color: #e76e63;
+}
+
 webview {
   background: #ffffff;
   border: none;

--- a/src/js/components/Browser.react.js
+++ b/src/js/components/Browser.react.js
@@ -154,7 +154,7 @@ class Browser extends React.Component<Props, State> {
     return selectors;
   };
 
-  highlightElements = () => {
+  highlightEditorElements = () => {
     if (this.props.editor.focusedField != null) {
       let field = this.props.editor.focusedField;
       let fieldName = null;
@@ -230,7 +230,7 @@ class Browser extends React.Component<Props, State> {
       prevProps.editor.finding != this.props.editor.finding
     ) {
       highlighted = true;
-      this.highlightElements();
+      this.highlightEditorElements();
     }
     if (prevProps.editor.warningSelector != this.props.editor.warningSelector) {
       highlighted = true;
@@ -262,7 +262,7 @@ class Browser extends React.Component<Props, State> {
         'did-get-response-details',
         this.getResponseDetails
       );
-      this.webview.addEventListener('dom-ready', this.highlightElements);
+      this.webview.addEventListener('dom-ready', this.highlightEditorElements);
       this.webview.addEventListener('dom-ready', this.resetProgress);
       // eslint-disable-next-line no-console
       this.webview.addEventListener('error', console.log.bind(console));

--- a/src/js/components/Browser.react.js
+++ b/src/js/components/Browser.react.js
@@ -194,7 +194,28 @@ class Browser extends React.Component<Props, State> {
           contextSelector: context,
         });
       }
-    } else {
+    }
+  };
+
+  highlightWarningElements = () => {
+    if (this.props.editor.warningSelector !== null) {
+      this.webview.send('message', {
+        type: BrowserMessageTypes.HIGHLIGHT_WARNING_ELEMENTS,
+        selector: this.props.editor.warningSelector,
+      });
+      this.webview.send('message', {
+        type: BrowserMessageTypes.FETCH_ATTRIBUTES,
+        selector: this.props.editor.warningSelector,
+        contextSelector: 'html',
+      });
+    }
+  };
+
+  clearHighlightElements = () => {
+    if (
+      this.props.editor.warningSelector === null &&
+      this.props.editor.focusedField == null
+    ) {
       this.webview.send('message', {
         type: BrowserMessageTypes.CLEAR_HIGHLIGHTS,
       });
@@ -202,11 +223,21 @@ class Browser extends React.Component<Props, State> {
   };
 
   componentDidUpdate(prevProps: Props, prevState: State) {
+    let highlighted = false;
     if (
-      prevProps.editor.focusedField != this.props.editor.focusedField ||
+      JSON.stringify(prevProps.editor.focusedField) !=
+        JSON.stringify(this.props.editor.focusedField) ||
       prevProps.editor.finding != this.props.editor.finding
     ) {
+      highlighted = true;
       this.highlightElements();
+    }
+    if (prevProps.editor.warningSelector != this.props.editor.warningSelector) {
+      highlighted = true;
+      this.highlightWarningElements();
+    }
+    if (highlighted) {
+      this.clearHighlightElements();
     }
   }
 

--- a/src/js/components/Preview.react.js
+++ b/src/js/components/Preview.react.js
@@ -13,8 +13,9 @@ import React from 'react';
 import classNames from 'classnames';
 import RuleExporter from '../utils/RuleExporter';
 import type { BaseProps } from '../containers/AppContainer.react';
+import type { WarningProps } from './Warnings.react';
 import { Loader, Dimmer, Form, Tab } from 'semantic-ui-react';
-import Warning from './Warning.react';
+import Warnings from './Warnings.react';
 import debounce from '../utils/debounce';
 import EditorActions from '../data/EditorActions';
 
@@ -30,7 +31,7 @@ type Props = BaseProps & { hidden: boolean };
 type State = {
   previewLoading: boolean,
   activeTab: number,
-  warnings: any,
+  warnings: WarningProps[],
   previewHtml: ?string,
   //sourceHtml: ?string,
   errorHtml: ?string,
@@ -245,7 +246,7 @@ class Preview extends React.Component<Props, State> {
       'Warnings',
       'warnings',
       () => {},
-      <Warning
+      <Warnings
         activeTab={this.state.activeTab}
         warningSelector={this.props.editor.warningSelector}
         warnings={this.state.warnings}

--- a/src/js/components/Preview.react.js
+++ b/src/js/components/Preview.react.js
@@ -14,7 +14,9 @@ import classNames from 'classnames';
 import RuleExporter from '../utils/RuleExporter';
 import type { BaseProps } from '../containers/AppContainer.react';
 import { Loader, Dimmer, Form, Tab } from 'semantic-ui-react';
+import Warning from './Warning.react';
 import debounce from '../utils/debounce';
+import EditorActions from '../data/EditorActions';
 
 import webserver from '../utils/preview-webserver';
 import { BrowserWindow } from 'electron';
@@ -28,7 +30,7 @@ type Props = BaseProps & { hidden: boolean };
 type State = {
   previewLoading: boolean,
   activeTab: number,
-  warnings: string[],
+  warnings: any,
   previewHtml: ?string,
   //sourceHtml: ?string,
   errorHtml: ?string,
@@ -140,6 +142,7 @@ class Preview extends React.Component<Props, State> {
             warnings: warnings,
             errorHtml: response.error,
           });
+          EditorActions.setWarningSelector(null);
           this.reloadPreview();
           if (this.state.activeTab === WARNING_TAB_INDEX) {
             this.previewFinishedLoading();
@@ -177,6 +180,7 @@ class Preview extends React.Component<Props, State> {
   handleTabChange = (event: any, data: any) => {
     this.previewLoading();
     this.setState({ activeTab: data.activeIndex });
+    EditorActions.setWarningSelector(null);
     if (data.activeIndex == PREVIEW_TAB_INDEX) {
       this.reloadPreview();
     } else if (data.activeIndex == SOURCE_TAB_INDEX) {
@@ -241,21 +245,11 @@ class Preview extends React.Component<Props, State> {
       'Warnings',
       'warnings',
       () => {},
-      <div className="warning-tab">
-        {this.state.warnings.length > 0 ? (
-          <ul>
-            {this.state.warnings.map((warning, index) => (
-              <li key={`warning-${index}`}>{warning}</li>
-            ))}
-          </ul>
-        ) : (
-          <div className="message-container">
-            <p className="message">
-              No warnings: All fields were successfully connected.
-            </p>
-          </div>
-        )}
-      </div>
+      <Warning
+        activeTab={this.state.activeTab}
+        warningSelector={this.props.editor.warningSelector}
+        warnings={this.state.warnings}
+      />
     );
     return [previewPane, sourcePane, warningsPane];
   };

--- a/src/js/components/Warning.react.js
+++ b/src/js/components/Warning.react.js
@@ -68,9 +68,13 @@ class Warning extends React.Component<Props, State> {
                     ? () => this.warningOnClick(warning.selector, index)
                     : () => {}
                 }
-                className={`warning ${
-                  this.state.activeWarning === index ? 'active' : ''
-                }`}
+                className={
+                  warning.selector && warning.selector !== 'html'
+                    ? `warning ${
+                      this.state.activeWarning === index ? 'active' : ''
+                    }`
+                    : ''
+                }
               >
                 {warning.message}
               </li>

--- a/src/js/components/Warning.react.js
+++ b/src/js/components/Warning.react.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2017-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import React from 'react';
+
+import EditorActions from '../data/EditorActions';
+
+type Props = {
+  activeTab: number,
+  warningSelector: ?string,
+  warnings: any,
+};
+
+type State = {
+  activeWarning: ?number,
+};
+
+class Warning extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      activeWarning: null,
+    };
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    if (
+      JSON.stringify(nextProps.warnings) !==
+        JSON.stringify(this.props.warnings) ||
+      (nextProps.warningSelector === null &&
+        nextProps.warningSelector !== this.props.warningSelector)
+    ) {
+      this.setState({ activeWarning: null });
+    }
+  }
+
+  warningOnClick = (selector: string, index: number) => {
+    if (!selector) {
+      return;
+    }
+    if (index !== this.state.activeWarning) {
+      EditorActions.blur();
+      EditorActions.setWarningSelector(selector);
+      this.setState({ activeWarning: index });
+    } else {
+      this.setState({ activeWarning: null });
+      EditorActions.setWarningSelector(null);
+    }
+  };
+
+  render() {
+    return (
+      <div className="warning-tab">
+        {this.props.warnings.length > 0 ? (
+          <ul>
+            {this.props.warnings.map((warning, index) => (
+              <li
+                key={`warning-${index}`}
+                onClick={
+                  warning.selector
+                    ? () => this.warningOnClick(warning.selector, index)
+                    : () => {}
+                }
+                className={`warning ${
+                  this.state.activeWarning === index ? 'active' : ''
+                }`}
+              >
+                {warning.message}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="message-container">
+            <p className="message">
+              No warnings: All fields were successfully connected.
+            </p>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+module.exports = Warning;

--- a/src/js/components/Warnings.react.js
+++ b/src/js/components/Warnings.react.js
@@ -12,17 +12,23 @@ import React from 'react';
 
 import EditorActions from '../data/EditorActions';
 
+export type WarningProps = {
+  message: ?string,
+  selector: ?string,
+  field: ?string,
+};
+
 type Props = {
   activeTab: number,
   warningSelector: ?string,
-  warnings: any,
+  warnings: WarningProps[],
 };
 
 type State = {
   activeWarning: ?number,
 };
 
-class Warning extends React.Component<Props, State> {
+class Warnings extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -41,7 +47,7 @@ class Warning extends React.Component<Props, State> {
     }
   }
 
-  warningOnClick = (selector: string, index: number) => {
+  warningOnClick = (selector: ?string, index: ?number) => {
     if (!selector) {
       return;
     }
@@ -92,4 +98,4 @@ class Warning extends React.Component<Props, State> {
   }
 }
 
-module.exports = Warning;
+module.exports = Warnings;

--- a/src/js/data/EditorActionTypes.js
+++ b/src/js/data/EditorActionTypes.js
@@ -18,6 +18,7 @@ const EditorActionTypes = {
   START_TOUR: 'START_TOUR',
   STOP_TOUR: 'STOP_TOUR',
   LOAD_URL: 'LOAD_URL',
+  SET_WARNING_SELECTOR: 'SET_WARNING_SELECTOR',
 };
 
 export type EditorActionType = $Values<typeof EditorActionTypes>;

--- a/src/js/data/EditorActions.js
+++ b/src/js/data/EditorActions.js
@@ -70,6 +70,12 @@ class EditorActions {
       url,
     });
   }
+  static setWarningSelector(selector: ?string) {
+    RulesEditorDispatcher.dispatch({
+      type: EditorActionTypes.SET_WARNING_SELECTOR,
+      selector,
+    });
+  }
 }
 
 module.exports = EditorActions;

--- a/src/js/data/EditorStore.js
+++ b/src/js/data/EditorStore.js
@@ -43,11 +43,16 @@ class EditorStore extends ReduceStore<Editor> {
   reduce(state: Editor, action: Action): Editor {
     switch (action.type) {
       case EditorActionTypes.FOCUS_FIELD:
-        return state.set('focusedField', action.field);
+        return state
+          .set('focusedField', action.field)
+          .set('warningSelector', null);
       case EditorActionTypes.BLUR:
         return state.remove('focusedField');
       case EditorActionTypes.START_FINDING:
-        return state.set('focusedField', action.field).set('finding', true);
+        return state
+          .set('focusedField', action.field)
+          .set('finding', true)
+          .set('warningSelector', null);
 
       case EditorActionTypes.STOP_FINDING:
         return state.set('finding', false);
@@ -71,6 +76,9 @@ class EditorStore extends ReduceStore<Editor> {
           );
         }
         return state.set('finding', false);
+
+      case EditorActionTypes.SET_WARNING_SELECTOR:
+        return state.set('warningSelector', action.selector);
 
       case EditorActionTypes.FILTER_RULES:
         if (action.categories != null) {

--- a/src/js/models/BrowserMessage.js
+++ b/src/js/models/BrowserMessage.js
@@ -19,6 +19,7 @@ export const BrowserMessageTypes = {
   ATTRIBUTES_RETRIEVED: 'attributes_retrieved',
   ELEMENT_SELECTED: 'element_selected',
   HIGHLIGHT_ELEMENT: 'highlight_element',
+  HIGHLIGHT_WARNING_ELEMENTS: 'highlight_warning_elements',
   CLEAR_HIGHLIGHTS: 'clear_highlights',
 };
 
@@ -72,6 +73,15 @@ export type HighlightElementMessage = {
 };
 
 /**
+ * HighlightWarningElementsMessage
+ */
+export type HighlightWarningElementsMessage = {
+  type: 'highlight_warning_elements',
+  selector: string,
+  contextSelector: string,
+};
+
+/**
  * ClearHighlightsMessage
  */
 export type ClearHighlightsMessage = {
@@ -87,4 +97,5 @@ export type BrowserMessage =
   | AttributesRetrievedMessage
   | ElementSelectedMessage
   | HighlightElementMessage
+  | HighlightWarningElementsMessage
   | ClearHighlightsMessage;

--- a/src/js/models/Editor.js
+++ b/src/js/models/Editor.js
@@ -25,6 +25,7 @@ type EditorRecord = {
   categories: Set<RuleCategory>,
   takeTour: boolean,
   url: string,
+  warningSelector: ?string,
 };
 
 export const EditorFactory: RecordFactory<EditorRecord> = Record({
@@ -41,6 +42,7 @@ export const EditorFactory: RecordFactory<EditorRecord> = Record({
   ]),
   takeTour: false,
   url: homeURL,
+  warningSelector: null,
 });
 
 export type Editor = RecordOf<EditorRecord> & EditorFactory;

--- a/src/js/webview/WebviewUtils.js
+++ b/src/js/webview/WebviewUtils.js
@@ -16,6 +16,7 @@ const highlightClass = 'facebook-instant-articles-builder-highlight';
 const hoverClass = 'facebook-instant-articles-builder-hover';
 const contextClass = 'facebook-instant-articles-builder-context';
 const selectingClass = 'facebook-instant-articles-builder-selecting';
+const warningClass = 'facebook-instant-articles-builder-warning';
 
 export type ElementFilter = (element: Element) => Element;
 const elementFilters: Map<string, ElementFilter> = new Map();
@@ -54,17 +55,19 @@ export class WebviewUtils {
   static clearHighlights(): void {
     // Remove class form existing highlighted elements
     let oldHighlightedElements = document.querySelectorAll(
-      `.${highlightClass}, .${hoverClass}`
+      `.${highlightClass}, .${hoverClass}, .${warningClass}`
     );
     oldHighlightedElements.forEach(function(element) {
       element.classList.remove(highlightClass);
       element.classList.remove(hoverClass);
+      element.classList.remove(warningClass);
     });
   }
 
-  static highlightElementsBySelector(
+  static highlightElements(
     selector: string,
-    contextSelector: string
+    contextSelector: string,
+    className: string
   ): void {
     WebviewUtils.clearHighlights();
     if (selector == '') {
@@ -75,11 +78,21 @@ export class WebviewUtils {
     for (let context of contextElements) {
       let elements = context.querySelectorAll(selector);
       elements.forEach(function(element) {
-        element.classList.add(highlightClass);
+        element.classList.add(className);
       });
     }
   }
 
+  static highlightElementsBySelector(
+    selector: string,
+    contextSelector: string
+  ): void {
+    this.highlightElements(selector, contextSelector, highlightClass);
+  }
+
+  static highlightWarningElementsBySelector(selector: string): void {
+    this.highlightElements(selector, 'html', warningClass);
+  }
   /**
    * Register an ElementFilter for the given fieldName being selected.
    *

--- a/src/js/webview/webview.js
+++ b/src/js/webview/webview.js
@@ -39,6 +39,11 @@ function receiveMessage(message: BrowserMessage): void {
       );
       break;
 
+    case BrowserMessageTypes.HIGHLIGHT_WARNING_ELEMENTS:
+      WebviewStateMachine.state = WebviewStates.DEFAULT;
+      WebviewUtils.highlightWarningElementsBySelector(message.selector);
+      break;
+
     case BrowserMessageTypes.SELECT_ELEMENT:
       WebviewUtils.clearHighlights();
       WebviewStateMachine.contextSelector = message.selector;
@@ -151,10 +156,17 @@ function handleSelectElement(event: MouseEvent) {
 
   const selector = selectors[0];
   if (selector != null) {
-    WebviewUtils.highlightElementsBySelector(
-      selector,
-      WebviewStateMachine.contextSelector
-    );
+    if (
+      WebviewStateMachine.state ===
+      BrowserMessageTypes.HIGHLIGHT_WARNING_ELEMENTS
+    ) {
+      WebviewUtils.highlightWarningElementsBySelector(selector);
+    } else {
+      WebviewUtils.highlightElementsBySelector(
+        selector,
+        WebviewStateMachine.contextSelector
+      );
+    }
   }
 
   WebviewStateMachine.state = WebviewStates.DEFAULT;

--- a/webserver/article.php
+++ b/webserver/article.php
@@ -105,10 +105,19 @@ function get_instant_article($html_markup, $url, $rules, &$response) {
 
   $warnings = $transformer->getWarnings();
 
-  $string_func = function($warning) {
-    return $warning->__toString();
+  $warnings_func = function($warning) {
+    $warning_obj = new stdClass();
+    $warning_obj->message = $warning->__toString();
+
+    if (method_exists($warning,'getSelector')) {
+      $warning_obj->selector = $warning->getSelector() ?: null;
+    }
+    if (method_exists($warning,'getFields')) {
+      $warning_obj->field = $warning->getFields() ?: null;
+    }
+    return $warning_obj;
   };
-  $warnings = array_map($string_func, $warnings);
+  $warnings = array_map($warnings_func, $warnings);
   $response->warnings = $warnings;
 
   try_set_cached_value($cache_key, $warnings, CACHE_KEY_TYPE_WARNINGS);


### PR DESCRIPTION
The warning tab display a list of warnings.
When clicking in one of the items, the element will be highlighted in the page to facilitate the identification of the warning is related to.
<img width="1419" alt="Screen Shot 2021-03-22 at 19 47 28" src="https://user-images.githubusercontent.com/78859914/112067838-837edb80-8b47-11eb-8c1f-646312adc169.png">
<img width="1427" alt="Screen Shot 2021-03-22 at 19 47 35" src="https://user-images.githubusercontent.com/78859914/112067849-87126280-8b47-11eb-9030-1bc4cac5ce9e.png">
<img width="1434" alt="Screen Shot 2021-03-22 at 19 47 44" src="https://user-images.githubusercontent.com/78859914/112067853-88438f80-8b47-11eb-854d-eb500223ddf6.png">

The highlight will be removed when the warning is clicked again, every time preview loads again or if the focus is set in one of the rules fields.

Required: https://github.com/facebook/facebook-instant-articles-sdk-php/pull/369