### PR TITLE
Use GitHub URL for preview logo

### DIFF
--- a/webserver/styles/default.style.json
+++ b/webserver/styles/default.style.json
@@ -1104,7 +1104,7 @@
 		"accent_color": "#FFFFFF",
 		"background_color": "#3b5998",
 		"logo": {
-			"full_resolution_url": "preview-logo.png",
+			"full_resolution_url": "https://raw.githubusercontent.com/facebook/instant-articles-builder/master/webserver/preview-logo.png",
 			"full_resolution_width": 602,
 			"full_resolution_height": 128,
 			"thumbnail_url": "preview-logo.svg",


### PR DESCRIPTION
This PR fixes a bug that was preventing the IA Preview logo from displaying. The fix was to replace the relative URL was an absolute one pointing to the logo in the master branch of this repo.

![image](https://user-images.githubusercontent.com/18663703/114461659-011a9200-9bb0-11eb-887e-a9ed34010080.png)


Fixes #166 