### PR TITLE
Upgrade build web server PHP version to 7.4.9

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ message "Downloading PHP binaries for Windows..."
 rm -Rf bin
 mkdir bin
 cd bin
-curl -o php.zip https://windows.php.net/downloads/releases/archives/php-5.6.36-Win32-VC11-x86.zip
+curl -o php.zip https://windows.php.net/downloads/releases/archives/php-7.4.9-Win32-vc15-x86.zip
 message "Extracting PHP binary..."
 unzip php.zip -d ./php
 rm php.zip


### PR DESCRIPTION
This PR upgrades the version used by the build script of PHP to 7.4.9. The previous version of PHP that was used was generating some errors in the latest version of Windows because of some missing libraries.

I went with version 7 and not version 8 because with the latter the web server scripts raise some exceptions, so in order to upgrade to PHP 8 we will have to upgrade the scripts too.

To test the PR you can run the build command and test the Windows build. As soon as you open the tool you should see the Preview tab showing the message "Open an article..." instead of just seeing the loading icon staying there forever.