### PR TITLE
chore: Add PHP built in for MacOS

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/electron-packager/test/.*
 .*/webserver/*
 .*/build/*
+.*/**/malformed_package_json/package.json
 
 [include]
 node_modules/electron

--- a/build.sh
+++ b/build.sh
@@ -18,15 +18,31 @@ message "Downloading PHP binaries for Windows..."
 rm -Rf bin
 mkdir bin
 cd bin
-curl -o php.zip https://windows.php.net/downloads/releases/archives/php-7.4.9-Win32-vc15-x86.zip
+mkdir php
+cd php
+curl -o php-win32.zip https://windows.php.net/downloads/releases/archives/php-7.4.9-Win32-vc15-x86.zip
 message "Extracting PHP binary..."
-unzip php.zip -d ./php
-rm php.zip
+unzip php-win32.zip -d ./win32
+rm php-win32.zip
 message "PHP binary extracted"
-cp ../php.ini ./php/php.ini
+cp ../../php.ini ./win32/php.ini
+
+message "Downloading PHP binaries for Mac..."
+curl --insecure --show-error --location --globoff https://github.com/php/php-src/archive/refs/tags/php-7.4.29.tar.gz | tar -zx
+message "PHP source code downloaded"
+cd php-src-php-7.4.29
+message "Configuring PHP source code..."
+./buildconf --force
+mkdir ../darwin
+./configure --prefix=$(pwd)/../darwin --enable-shared=no --enable-static=yes --without-iconv --without-sqlite3 -with-openssl=$(which openssl)
+message "Installing PHP binaries for Mac..."
+make -j8
+make install
+cd ..
+rm -r -f php-src-php-7.4.29
 
 message "Installing PHP dependencies..."
-cd ..
+cd ../../
 cd webserver
 composer install
 message "PHP dependencies installed"

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ cd php-src-php-7.4.29
 message "Configuring PHP source code..."
 ./buildconf --force
 mkdir ../darwin
-./configure --prefix=$(pwd)/../darwin --enable-shared=no --enable-static=yes --without-iconv --without-sqlite3 -with-openssl=$(which openssl)
+./configure --prefix=$(pwd)/../darwin --enable-shared=no --enable-static=yes --without-iconv --without-pdo-sqlite --without-sqlite3 -with-openssl=$(which openssl)
 message "Installing PHP binaries for Mac..."
 make -j8
 make install

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "devtron": "^1.4.0",
-    "electron": "^11.3.0",
+    "electron": "^11.5.0",
     "electron-packager": "^15.2.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-15": "^1.4.1",

--- a/src/js/utils/preview-webserver.js
+++ b/src/js/utils/preview-webserver.js
@@ -46,9 +46,17 @@ class PreviewWebserver {
       this.phpServer.server({
         port: this.port,
         base: path.resolve(__dirname) + '/../../../webserver',
-        bin: path.resolve(__dirname) + '/../../../bin/php/php.exe',
+        bin: path.resolve(__dirname) + '/../../../bin/php/win32/php.exe',
       });
-    } else {
+    } else if (process.platform === 'darwin'){
+      var x = this.phpServer.server({
+        port: this.port,
+        base: path.resolve(__dirname) + '/../../../webserver',
+        bin: path.resolve(__dirname) + '/../../../bin/php/darwin/bin/php',
+      });
+    }
+    else
+    {
       this.phpServer.server({
         port: this.port,
         base: path.resolve(__dirname) + '/../../../webserver',

--- a/src/js/utils/preview-webserver.js
+++ b/src/js/utils/preview-webserver.js
@@ -49,7 +49,7 @@ class PreviewWebserver {
         bin: path.resolve(__dirname) + '/../../../bin/php/win32/php.exe',
       });
     } else if (process.platform === 'darwin'){
-      var x = this.phpServer.server({
+      this.phpServer.server({
         port: this.port,
         base: path.resolve(__dirname) + '/../../../webserver',
         bin: path.resolve(__dirname) + '/../../../bin/php/darwin/bin/php',


### PR DESCRIPTION
## This PR adds PHP built-in for MacOS App versions. 

Apple removed the PHP installed by default on MacOS Monterey and with that, the app cannot find PHP and cannot preview the Article, leaving a loading icon forever.

So now, I added the version `7.4.29` of the PHP built-in for the MacOS systems.

To test the PR you can run the build command and test the App in a MacOS Monterey. As soon as you open the tool you should see the Preview tab showing the message "Open an article..." instead of just seeing the loading icon staying there forever.