### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![CircleCI](https://circleci.com/gh/facebook/instant-articles-builder.svg?style=shield)](https://circleci.com/gh/facebook/instant-articles-builder)
 
+## 🚨 Important Note
+
+** ⚠️ Instant Articles will not be available starting April 20, 2023**
+
+All related developer tools will be archived.
+
+---
+
 **Instant Articles Builder** helps you to create a template to build [Facebook Instant Articles](https://instantarticles.fb.com/) from articles on your website.
 
 Try it out (Windows/Mac): https://facebook.github.io/instant-articles-builder/

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -21,6 +21,7 @@ h1 .ia {
 }
 
 body,
+#notice,
 #root,
 #wrapper {
   margin: 0;
@@ -36,6 +37,10 @@ header {
   display: flex;
   align-items: center;
   padding-left: 10px;
+}
+
+#notice {
+  padding-left: 20px;
 }
 
 header > img {

--- a/src/js/components/App.react.js
+++ b/src/js/components/App.react.js
@@ -74,6 +74,10 @@ class App extends React.Component<Props> {
             <span className="app-name">Builder</span>
           </h1>
         </header>
+        <div id="notice">
+          <h2>⚠️ Instant Articles will not be available starting April 20, 2023</h2>
+          <span>All related developer tools will be archived.</span>
+        </div>
         <div id="content-wrapper">
           <main id="content">
             <Browser {...this.props} />

--- a/src/js/components/NUX.react.js
+++ b/src/js/components/NUX.react.js
@@ -24,8 +24,8 @@ export class NUX extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.state = {
-      modalOpen: !!settings.get('nux.skip'),
-      skip: settings.get('nux.skip'),
+      modalOpen: false,
+      skip: true,
     };
   }
 


### PR DESCRIPTION
This PR adds warnings to the tool about the upcoming deprecation of Instant Articles. The changes are:

1. Disable NUX (since it does not make sense to encourage use of the tool)
2. Add a warning header
3. Update the Readme file with a warning

I plan to add a new message once Instant Articles has been deprecated and to archive the repo afterwards.